### PR TITLE
Playback delay and background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Changed
 
-- (Changes since last release will be listed here)
+- Use the effective configured stream format on web playback and keep Safari on original format when OGG is selected.
+- Harden Android native queue setup by trying both JSON-string and array `setQueue` payload signatures before falling back.
+
+### Fixed
+
+- Replace the malformed `expo-audio+1.1.1` patch with a valid patch-package diff so native queue bridge methods apply during install.
+- Prevent lock-screen metadata and native seek bridge errors from forcing JS-only track advancement in Android album playback.
 
 ## [0.1.4] - 2026-02-14
 

--- a/patches/expo-audio+1.1.1.patch
+++ b/patches/expo-audio+1.1.1.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt b/node_modules/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
-index 49a53af..5475ff7 100644
+index 49a53af..4da60e3 100644
 --- a/node_modules/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
 +++ b/node_modules/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
-@@ -422,6 +422,18 @@ class AudioModule : Module() {
+@@ -422,6 +422,23 @@ class AudioModule : Module() {
          }
        }
  
@@ -27,21 +27,22 @@ index 49a53af..5475ff7 100644
          runOnMain {
            ref.setActiveForLockScreen(active, metadata, options)
 diff --git a/node_modules/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt b/node_modules/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
-index 320062e..cfa8906 100644
+index 320062e..69c60f4 100644
 --- a/node_modules/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
 +++ b/node_modules/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
-@@ -1,5 +1,6 @@
- package expo.modules.audio
- 
-+import android.net.Uri
+@@ -3,6 +3,7 @@ package expo.modules.audio
  import android.Manifest
  import android.content.Context
  import android.content.pm.PackageManager
++import android.net.Uri
+ import android.media.audiofx.Visualizer
+ import android.util.Log
+ import androidx.core.content.ContextCompat
 @@ -100,6 +101,23 @@ class AudioPlayer(
      startUpdating()
    }
  
-+  /** Set a queue of URIs; ExoPlayer will advance to the next track when current ends (works when app is backgrounded). */
++  /** Set a queue of URIs; ExoPlayer will advance when each track ends. */
 +  fun setMediaQueue(uris: List<String>, startIndex: Int) {
 +    val items = uris.map { MediaItem.fromUri(Uri.parse(it)) }
 +    if (items.isEmpty()) return
@@ -51,7 +52,7 @@ index 320062e..cfa8906 100644
 +    startUpdating()
 +  }
 +
-+  /** Seek to a specific item in the queue by index. */
++  /** Seek to a specific queue item by index. */
 +  fun seekToMediaItem(index: Int) {
 +    if (index in 0 until ref.mediaItemCount) {
 +      ref.seekTo(index, 0L)

--- a/src/store/playerStore.ts
+++ b/src/store/playerStore.ts
@@ -14,17 +14,26 @@ import { getToken } from '../api/client';
 import { useSettingsStore } from './settingsStore';
 
 /**
- * Web: Safari does not support OGG, so use original (MP3/M4A/AAC/FLAC work in Safari).
- * Other browsers get OGG for consistent behavior. Native uses settings.
+ * Stream format selection:
+ * - Respect configured effective format on every platform.
+ * - On Safari/WebKit, force original because OGG is not supported reliably.
  */
 function getStreamFormat(): 'original' | 'ogg' {
+  const preferred = useSettingsStore.getState().getEffectiveStreamFormat();
   if (Platform.OS === 'web') {
-    if (typeof navigator !== 'undefined' && navigator.vendor?.includes('Apple') && typeof navigator.userAgent === 'string' && !navigator.userAgent.includes('CriOS') && !navigator.userAgent.includes('FxiOS')) {
+    if (
+      preferred === 'ogg' &&
+      typeof navigator !== 'undefined' &&
+      navigator.vendor?.includes('Apple') &&
+      typeof navigator.userAgent === 'string' &&
+      !navigator.userAgent.includes('CriOS') &&
+      !navigator.userAgent.includes('FxiOS')
+    ) {
       return 'original';
     }
-    return 'ogg';
+    return preferred;
   }
-  return useSettingsStore.getState().getEffectiveStreamFormat();
+  return preferred;
 }
 
 /** Start prestarting (play next at volume 0) this many seconds before end so it has time to load. Load time can be ~12s with transcoding or slow networks. */
@@ -113,6 +122,38 @@ function scheduleAdvance(remainingMs: number, trackId: number, onAdvance: () => 
 const activePlayers = new Set<AudioPlayer>();
 let suppressRemoteSkipDetectionUntil = 0;
 let remoteSkipInFlight = false;
+
+function trySetAndroidNativeQueue(player: AudioPlayer, urls: string[], startIndex: number): boolean {
+  const setQueueFn = (
+    player as unknown as {
+      setQueue?: ((urisJson: string, startIndex: number) => void) | ((uris: string[], startIndex: number) => void);
+    }
+  ).setQueue;
+  if (typeof setQueueFn !== 'function') return false;
+  // Support both patched and upstream queue signatures.
+  try {
+    (setQueueFn as (urisJson: string, index: number) => void).call(player, JSON.stringify(urls), startIndex);
+    return true;
+  } catch {
+    try {
+      (setQueueFn as (uris: string[], index: number) => void).call(player, urls, startIndex);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+function trySeekToAndroidNativeQueueIndex(player: AudioPlayer, index: number): boolean {
+  const seekToMediaItem = (player as unknown as { seekToMediaItem?: (targetIndex: number) => void }).seekToMediaItem;
+  if (typeof seekToMediaItem !== 'function') return false;
+  try {
+    seekToMediaItem.call(player, index);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 function stopAndRemoveAllPlayers(): void {
   for (const p of activePlayers) {
@@ -289,32 +330,36 @@ function preloadNext(track: Track): AudioPlayer | null {
 /** Update lock screen / Now Playing metadata (iOS/Android). No-op on web. */
 function setLockScreenMetadata(player: AudioPlayer | null, track: Track | null): void {
   if (!player) return;
-  const setActive = (player as {
-    setActiveForLockScreen?(
-      active: boolean,
-      metadata?: Record<string, string | undefined>,
-      options?: { showSeekForward?: boolean; showSeekBackward?: boolean }
-    ): void;
-  }).setActiveForLockScreen;
-  const updateMetadata = (player as {
-    updateLockScreenMetadata?(metadata: Record<string, string | undefined>): void;
-  }).updateLockScreenMetadata;
-  if (!setActive) return;
-  if (!track) {
-    setActive.call(player, false);
-    return;
+  try {
+    const setActive = (player as {
+      setActiveForLockScreen?(
+        active: boolean,
+        metadata?: Record<string, string | undefined>,
+        options?: { showSeekForward?: boolean; showSeekBackward?: boolean }
+      ): void;
+    }).setActiveForLockScreen;
+    const updateMetadata = (player as {
+      updateLockScreenMetadata?(metadata: Record<string, string | undefined>): void;
+    }).updateLockScreenMetadata;
+    if (!setActive) return;
+    if (!track) {
+      setActive.call(player, false);
+      return;
+    }
+    const metadata = {
+      title: track.title,
+      artist: track.artist_name || 'Unknown',
+      albumTitle: track.album_title,
+      artworkUrl: getArtworkMetadataUrl(track),
+    };
+    setActive.call(player, true, metadata, {
+      showSeekForward: true,
+      showSeekBackward: true,
+    });
+    updateMetadata?.call(player, metadata);
+  } catch {
+    /* ignore lock-screen metadata failures so queue playback keeps running */
   }
-  const metadata = {
-    title: track.title,
-    artist: track.artist_name || 'Unknown',
-    albumTitle: track.album_title,
-    artworkUrl: getArtworkMetadataUrl(track),
-  };
-  setActive.call(player, true, metadata, {
-    showSeekForward: true,
-    showSeekBackward: true,
-  });
-  updateMetadata?.call(player, metadata);
 }
 
 /** Call play(); if not loaded yet, call again when isLoaded (keeps preload, no extra request). */
@@ -377,14 +422,13 @@ export const usePlayerStore = create<PlayerState>((set, get) => ({
       } else if (Platform.OS === 'android' && queue.length > 1) {
         // Native queue: ExoPlayer advances to next track when current ends, even when device is locked.
         // If setQueue/addListener aren't available (e.g. patch not applied or method not exposed to JS), fall back to single-track path.
+        let nativeQueueStarted = false;
         try {
           stopAndRemoveAllPlayers();
-          useNativeQueueAndroid = true;
-          sound = createAudioPlayer(null, { updateInterval: 150, downloadFirst: false });
+          sound = createAudioPlayer(getStreamUrl(currentTrack), { updateInterval: 150, downloadFirst: false });
           const urls = queue.map((t) => getStreamUrl(t));
-          const setQueueFn = (sound as unknown as { setQueue?: (urisJson: string, startIndex: number) => void }).setQueue;
-          if (typeof setQueueFn !== 'function') throw new Error('setQueue not available');
-          setQueueFn.call(sound, JSON.stringify(urls), currentIndex);
+          if (!trySetAndroidNativeQueue(sound, urls, currentIndex)) throw new Error('setQueue not available');
+          useNativeQueueAndroid = true;
           activePlayers.add(sound);
           const q = queue;
           sound.addListener('playbackStatusUpdate', (status: { currentMediaItemIndex?: number; currentTime?: number; duration?: number }) => {
@@ -399,13 +443,15 @@ export const usePlayerStore = create<PlayerState>((set, get) => ({
           sound.volume = currentVolume;
           setLockScreenMetadata(sound, currentTrack);
           sound.play();
+          nativeQueueStarted = true;
           set({ isLoading: false });
         } catch (e) {
-          if (sound) {
+          if (!nativeQueueStarted && sound) {
             removePlayer(sound);
             sound = null;
           }
           useNativeQueueAndroid = false;
+          console.warn('Native Android queue unavailable; falling back to JS track advancement', e);
           const nextIndex = currentIndex + 1;
           const nextTrack = nextIndex < queue.length ? queue[nextIndex] : null;
           sound = loadAndPlay(currentTrack, () => get().skipToNext(), onPosition, get().position, onPlaybackStarted);
@@ -457,11 +503,13 @@ export const usePlayerStore = create<PlayerState>((set, get) => ({
     let { queue, currentIndex, currentTrack, autoplayEnabled } = get();
     if (useNativeQueueAndroid && sound && currentIndex + 1 < queue.length) {
       const nextIndex = currentIndex + 1;
-      (sound as unknown as { seekToMediaItem: (index: number) => void }).seekToMediaItem(nextIndex);
-      const nextTrack = queue[nextIndex];
-      set({ currentIndex: nextIndex, currentTrack: nextTrack, position: 0, duration: nextTrack.duration ?? 0 });
-      setLockScreenMetadata(sound, nextTrack);
-      return;
+      if (trySeekToAndroidNativeQueueIndex(sound, nextIndex)) {
+        const nextTrack = queue[nextIndex];
+        set({ currentIndex: nextIndex, currentTrack: nextTrack, position: 0, duration: nextTrack.duration ?? 0 });
+        setLockScreenMetadata(sound, nextTrack);
+        return;
+      }
+      useNativeQueueAndroid = false;
     }
     if (currentIndex + 1 >= queue.length) {
       if (autoplayEnabled && currentTrack) {
@@ -564,11 +612,13 @@ export const usePlayerStore = create<PlayerState>((set, get) => ({
     const { position, queue, currentIndex } = get();
     if (useNativeQueueAndroid && sound && currentIndex > 0) {
       const prevIndex = currentIndex - 1;
-      (sound as unknown as { seekToMediaItem: (index: number) => void }).seekToMediaItem(prevIndex);
-      const prevTrack = queue[prevIndex];
-      set({ currentIndex: prevIndex, currentTrack: prevTrack, position: 0, duration: prevTrack.duration ?? 0 });
-      setLockScreenMetadata(sound, prevTrack);
-      return;
+      if (trySeekToAndroidNativeQueueIndex(sound, prevIndex)) {
+        const prevTrack = queue[prevIndex];
+        set({ currentIndex: prevIndex, currentTrack: prevTrack, position: 0, duration: prevTrack.duration ?? 0 });
+        setLockScreenMetadata(sound, prevTrack);
+        return;
+      }
+      useNativeQueueAndroid = false;
     }
     if (position > 3 && sound) {
       sound.seekTo(0);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix web playback startup delay by respecting stream format settings and resolve Android background track transitions by hardening the native queue and correcting a malformed patch.

The long-standing Android background playback issue was primarily caused by a malformed `expo-audio` patch, which prevented native queue methods from being reliably applied in builds. This PR regenerates the patch and makes the native queue initialization more resilient to non-critical errors, preventing silent fallbacks to the less robust JavaScript queue.

---
<p><a href="https://cursor.com/agents/bc-fd9be922-9d52-4873-b322-9c2fdc3c61b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd9be922-9d52-4873-b322-9c2fdc3c61b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->